### PR TITLE
Harden image build tooling and maintenance flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 *
+!Dockerfile.ubuntu
+!.dockerignore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,27 +17,32 @@ blocks:
               set -eu
 
               PUBLISH_IMAGE=0
+              PUBLISH_TAG=""
+              CACHE_FROM_ARGS=""
               if [ -n "${SEMAPHORE_GIT_TAG_NAME:-}" ]; then
-                IMAGE_TAG="$SEMAPHORE_GIT_TAG_NAME"
+                PUBLISH_TAG="$SEMAPHORE_GIT_TAG_NAME"
                 PUBLISH_IMAGE=1
               elif echo "${SEMAPHORE_GIT_BRANCH:-}" | grep -Eq '^php[0-9][0-9]$'; then
-                IMAGE_TAG="$SEMAPHORE_GIT_BRANCH"
+                PUBLISH_TAG="$SEMAPHORE_GIT_BRANCH"
                 PUBLISH_IMAGE=1
-              else
-                IMAGE_TAG="ci-${SEMAPHORE_GIT_SHA:-local}"
               fi
 
-              docker pull "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" || true
+              if [ "$PUBLISH_IMAGE" -eq 1 ]; then
+                docker pull "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG" || true
+                CACHE_FROM_ARGS="$CACHE_FROM_ARGS --cache-from $DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
+              fi
               docker pull "$DOCKER_USERNAME/$IMAGE_NAME:latest" || true
               docker pull "$BUILDER_IMAGE" || true
-              docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" --cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest" --cache-from "$BUILDER_IMAGE" -f Dockerfile.ubuntu -t "$IMAGE_NAME:$IMAGE_TAG" .
+              CACHE_FROM_ARGS="$CACHE_FROM_ARGS --cache-from $DOCKER_USERNAME/$IMAGE_NAME:latest --cache-from $BUILDER_IMAGE"
 
               if [ "$PUBLISH_IMAGE" -eq 1 ]; then
+                docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu -t "$IMAGE_NAME:$PUBLISH_TAG" .
                 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-                docker tag "$IMAGE_NAME:$IMAGE_TAG" "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
-                docker push "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
+                docker tag "$IMAGE_NAME:$PUBLISH_TAG" "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
+                docker push "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
               else
-                echo "Build-only branch: not publishing $IMAGE_NAME:$IMAGE_TAG"
+                docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu .
+                echo "Build-only branch: not publishing image"
               fi
       secrets:
         - name: dockerhub-1allen

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,19 +9,36 @@ blocks:
     skip:
       when: "branch = 'master'"
     task:
-      prologue:
-        commands:
-          - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
       jobs:
-        - name: docker build & push
+        - name: docker build
           commands:
             - checkout
-            - IMAGE_TAG=${SEMAPHORE_GIT_TAG_NAME:-$SEMAPHORE_GIT_BRANCH}
-            - docker pull "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" || true
-            - docker pull "$BUILDER_IMAGE" || true
-            - docker build --pull --cache-from "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" --cache-from "$BUILDER_IMAGE" -f Dockerfile.ubuntu -t "$IMAGE_NAME:$IMAGE_TAG" .
-            - docker tag "$IMAGE_NAME:$IMAGE_TAG" "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
-            - docker push "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
+            - |
+              set -eu
+
+              PUBLISH_IMAGE=0
+              if [ -n "${SEMAPHORE_GIT_TAG_NAME:-}" ]; then
+                IMAGE_TAG="$SEMAPHORE_GIT_TAG_NAME"
+                PUBLISH_IMAGE=1
+              elif echo "${SEMAPHORE_GIT_BRANCH:-}" | grep -Eq '^php[0-9][0-9]$'; then
+                IMAGE_TAG="$SEMAPHORE_GIT_BRANCH"
+                PUBLISH_IMAGE=1
+              else
+                IMAGE_TAG="ci-${SEMAPHORE_GIT_SHA:-local}"
+              fi
+
+              docker pull "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" || true
+              docker pull "$DOCKER_USERNAME/$IMAGE_NAME:latest" || true
+              docker pull "$BUILDER_IMAGE" || true
+              docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG" --cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest" --cache-from "$BUILDER_IMAGE" -f Dockerfile.ubuntu -t "$IMAGE_NAME:$IMAGE_TAG" .
+
+              if [ "$PUBLISH_IMAGE" -eq 1 ]; then
+                echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+                docker tag "$IMAGE_NAME:$IMAGE_TAG" "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
+                docker push "$DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG"
+              else
+                echo "Build-only branch: not publishing $IMAGE_NAME:$IMAGE_TAG"
+              fi
       secrets:
         - name: dockerhub-1allen
       env_vars:
@@ -31,3 +48,5 @@ blocks:
           value: php-apache
         - name: BUILDER_IMAGE
           value: spritsail/debian-builder:latest
+        - name: DOCKER_BUILDKIT
+          value: "1"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,37 +13,7 @@ blocks:
         - name: docker build
           commands:
             - checkout
-            - |
-              set -eu
-
-              PUBLISH_IMAGE=0
-              PUBLISH_TAG=""
-              CACHE_FROM_ARGS=""
-              if [ -n "${SEMAPHORE_GIT_TAG_NAME:-}" ]; then
-                PUBLISH_TAG="$SEMAPHORE_GIT_TAG_NAME"
-                PUBLISH_IMAGE=1
-              elif echo "${SEMAPHORE_GIT_BRANCH:-}" | grep -Eq '^php[0-9][0-9]$'; then
-                PUBLISH_TAG="$SEMAPHORE_GIT_BRANCH"
-                PUBLISH_IMAGE=1
-              fi
-
-              if [ "$PUBLISH_IMAGE" -eq 1 ]; then
-                docker pull "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG" || true
-                CACHE_FROM_ARGS="$CACHE_FROM_ARGS --cache-from $DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
-              fi
-              docker pull "$DOCKER_USERNAME/$IMAGE_NAME:latest" || true
-              docker pull "$BUILDER_IMAGE" || true
-              CACHE_FROM_ARGS="$CACHE_FROM_ARGS --cache-from $DOCKER_USERNAME/$IMAGE_NAME:latest --cache-from $BUILDER_IMAGE"
-
-              if [ "$PUBLISH_IMAGE" -eq 1 ]; then
-                docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu -t "$IMAGE_NAME:$PUBLISH_TAG" .
-                echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-                docker tag "$IMAGE_NAME:$PUBLISH_TAG" "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
-                docker push "$DOCKER_USERNAME/$IMAGE_NAME:$PUBLISH_TAG"
-              else
-                docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu .
-                echo "Build-only branch: not publishing image"
-              fi
+            - CI_GIT_BRANCH="${SEMAPHORE_GIT_BRANCH:-}" CI_GIT_TAG="${SEMAPHORE_GIT_TAG_NAME:-}" bash scripts/ci_docker_build.sh
       secrets:
         - name: dockerhub-1allen
       env_vars:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,17 +11,24 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
 - Keep `AGENTS.md`, `README.md`, `docs/maintenance.md`, scripts, config, and
   CI changes in `SHARED_FILES` when they should propagate to PHP version
   branches.
-- Do not replace the manual `imagick` build with `install-php-extensions
-  imagick` unless you have verified that the extension links against the custom
-  ImageMagick under `/usr/local`.
+- Keep `.dockerignore` in `SHARED_FILES`; the image does not copy repository
+  files, so docs, tests, scripts, agent state, and Git metadata should stay out
+  of the Docker build context.
+- Treat `php73` and `php74` as deprecated/frozen. Do not sync shared files,
+  update Dockerfile behavior, or move PHP 7 tags unless the user explicitly asks
+  for a critical emergency fix.
+- `imagick` is a bundled feature of this image. Do not replace the explicit
+  PECL `imagick` build with `install-php-extensions imagick` unless you have
+  verified that the extension still ships by default and links against the
+  custom ImageMagick under `/usr/local`.
 
 ## Dockerfile Rules
 
 - `Dockerfile.ubuntu` is the maintained image path.
-- The first stage copies `/usr/bin/install-php-extensions` from
-  `ghcr.io/mlocati/php-extension-installer:latest` into the final image. Keep
-  that binary in the final image so downstream images can install more
-  extensions without fetching the installer again.
+- The first stage copies `/usr/bin/install-php-extensions` from the public
+  `mlocati/php-extension-installer:latest` image into the final image. Keep that
+  binary in the final image so downstream images can install more extensions
+  without fetching the installer again.
 - Prefer `install-php-extensions` for ordinary extensions and downstream image
   customization, for example:
 
@@ -33,9 +40,20 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
 - When documenting downstream `grpc`, `redis`, or `protobuf` customization,
   show `install-php-extensions` as the preferred path. Keep manual `pecl
   install` examples only as legacy or troubleshooting context.
-- `imagick` is intentionally installed manually from PECL after the custom
-  ImageMagick build is copied into `/usr/local` and `ldconfig /usr/local/lib`
-  has run.
+- `imagick` is intentionally bundled by building the pinned PECL source after
+  the custom ImageMagick build is copied into `/usr/local` and
+  `ldconfig /usr/local/lib` has run.
+- Keep `docker-php-ext-configure imagick --with-imagick=/usr/local`; without
+  this, the build can silently link against Debian ImageMagick 6 packages.
+- Keep SHA-256 verification on downloaded ImageMagick and PECL `imagick`
+  archives. When version pins change, update the matching checksum in the same
+  Dockerfile change.
+- Keep `PKG_CONFIG_PATH=/usr/local/lib/pkgconfig` or equivalent configure-time
+  pathing so `imagick` prefers the custom ImageMagick under `/usr/local`.
+- Preserve BuildKit inline cache settings in Semaphore unless replacing them
+  with an equivalent or better cache strategy. PR branches and `latest` should
+  build only; Docker Hub publishing should stay limited to `phpXX` branches and
+  git tags.
 - `Dockerfile.ubuntu` is not part of shared-file sync. When image behavior
   changes on `latest`, apply the equivalent Dockerfile update to each `phpXX`
   branch while preserving that branch's `FROM webdevops/php-apache:X.Y` line
@@ -47,6 +65,8 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
 - `verify-image-tooling` checks `latest` plus supported branches by default.
   Legacy branches `php73` and `php74` are opt-in with
   `bash scripts/repo_sync.sh verify-image-tooling --legacy`.
+- `sync-shared` and `scripts/tags_update.sh` also skip legacy PHP 7 branches by
+  default. Use `--legacy` only for critical emergency maintenance.
 - If the base PHP minor changes, update only the `FROM webdevops/php-apache:X.Y`
   line on the corresponding `phpXX` branch unless shared behavior also changed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
 ## Dockerfile Rules
 
 - `Dockerfile.ubuntu` is the maintained image path.
-- The first stage copies `/usr/bin/install-php-extensions` from the public
-  `mlocati/php-extension-installer:latest` image into the final image. Keep that
-  binary in the final image so downstream images can install more extensions
-  without fetching the installer again.
+- The first stage copies `/usr/bin/install-php-extensions` from
+  `ghcr.io/mlocati/php-extension-installer:latest` into the final image. Keep
+  that binary in the final image so downstream images can install more
+  extensions without fetching the installer again.
 - Prefer `install-php-extensions` for ordinary extensions and downstream image
   customization, for example:
 
@@ -58,15 +58,18 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
   changes on `latest`, apply the equivalent Dockerfile update to each `phpXX`
   branch while preserving that branch's `FROM webdevops/php-apache:X.Y` line
   and extension compatibility pins.
-- Run `bash scripts/repo_sync.sh verify-image-tooling` before pushing image
-  behavior updates. This catches the failure mode where README examples mention
-  a downstream customization feature but semver branches such as `php82` do not
-  actually include it in their committed Dockerfiles.
+- For a `latest`-only PR, run `bash scripts/repo_sync.sh verify-image-tooling
+  latest`. After applying the equivalent Dockerfile updates to the supported
+  PHP branches, run `bash scripts/repo_sync.sh verify-image-tooling` before
+  pushing those branch updates. This catches the failure mode where README
+  examples mention a downstream customization feature but semver branches such
+  as `php82` do not actually include it in their committed Dockerfiles.
 - `verify-image-tooling` checks `latest` plus supported branches by default.
-  Legacy branches `php73` and `php74` are opt-in with
-  `bash scripts/repo_sync.sh verify-image-tooling --legacy`.
-- `sync-shared` and `scripts/tags_update.sh` also skip legacy PHP 7 branches by
-  default. Use `--legacy` only for critical emergency maintenance.
+  Check PHP 7 branches only by naming them explicitly, for example
+  `bash scripts/repo_sync.sh verify-image-tooling php73 php74`.
+- `sync-shared` and `scripts/tags_update.sh` also skip PHP 7 branches by
+  default. Name `php73` or `php74` explicitly only for critical emergency
+  maintenance.
 - If the base PHP minor changes, update only the `FROM webdevops/php-apache:X.Y`
   line on the corresponding `phpXX` branch unless shared behavior also changed.
 
@@ -79,7 +82,9 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
 4. Run `bash tests/repo_sync_test.sh`.
 5. For image behavior changes, verify the matching supported `phpXX` branches
    include the Dockerfile update before pushing semver tags such as `8.2`.
-6. Run `bash scripts/repo_sync.sh verify-image-tooling`.
+6. Run `bash scripts/repo_sync.sh verify-image-tooling latest` for a
+   `latest`-only PR, and run `bash scripts/repo_sync.sh verify-image-tooling`
+   after supported PHP branch Dockerfiles have been updated.
 7. If Docker is available, run a local image build and verify:
 
    ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ ImageMagick and PECL `imagick` than the upstream base image usually carries.
   with an equivalent or better cache strategy. PR branches and `latest` should
   build only; Docker Hub publishing should stay limited to `phpXX` branches and
   git tags.
+- Keep Docker build and publish logic in `scripts/ci_docker_build.sh`; CI
+  declaration files should only checkout, map provider-specific branch/tag
+  variables to `CI_GIT_BRANCH` and `CI_GIT_TAG`, and call that script.
 - `Dockerfile.ubuntu` is not part of shared-file sync. When image behavior
   changes on `latest`, apply the equivalent Dockerfile update to each `phpXX`
   branch while preserving that branch's `FROM webdevops/php-apache:X.Y` line

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,46 @@
+# PHP Apache Image Maintenance
+
+This context defines the maintenance language for the PHP Apache image branches
+and publication flow.
+
+## Language
+
+**PHP branch**:
+A repository branch named for a PHP minor line, such as `php73`, `php74`, or
+`php85`. These names are canonical and should not be replaced by policy labels.
+_Avoid_: legacy branch, frozen branch, final branch
+
+**Supported PHP branch**:
+A PHP branch that participates in default maintenance commands and routine image
+updates.
+_Avoid_: active branch
+
+**PHP7 branch**:
+One of the existing PHP branches for PHP 7, currently `php73` and `php74`.
+Maintenance that touches these branches should name them explicitly.
+_Avoid_: legacy branch, frozen branch, final branch
+
+**Source archive checksum**:
+A SHA-256 checksum recorded next to a pinned source archive version used by the
+image build.
+_Avoid_: best-effort checksum
+
+**Build-only CI**:
+A CI run that builds the Dockerfile as a smoke test without tagging or
+publishing an image.
+_Avoid_: local image tag, unpublished release
+
+**Bundled imagick**:
+The PECL `imagick` extension included in the published image and linked against
+the custom ImageMagick installation under `/usr/local`.
+_Avoid_: optional imagick, downstream imagick
+
+**Base-image compatibility cleanup**:
+Image-build logic that removes or neutralizes broken configuration inherited
+from the upstream base image when it prevents clean runtime startup.
+_Avoid_: feature removal
+
+**Shared file**:
+A repository maintenance file that should be propagated from `latest` to PHP
+branches because it is not branch-version-specific.
+_Avoid_: common file

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM mlocati/php-extension-installer:latest AS php-extension-installer
+FROM ghcr.io/mlocati/php-extension-installer:latest AS php-extension-installer
 
 FROM spritsail/debian-builder AS imagemagick-builder
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,32 +1,39 @@
-FROM ghcr.io/mlocati/php-extension-installer:latest AS php-extension-installer
+# syntax=docker/dockerfile:1
+
+FROM mlocati/php-extension-installer:latest AS php-extension-installer
 
 FROM spritsail/debian-builder AS imagemagick-builder
 
 # https://github.com/ImageMagick/ImageMagick/releases
 ARG IMAGEMAGICK_VERSION=7.1.2-26
+ARG IMAGEMAGICK_SHA256=d63594e334e1c410f600fb9370d78d49e4dc6f315722ca4ba083e864e5c354cb
+ARG DEBIAN_FRONTEND=noninteractive
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV MAKEFLAGS="-j$(nproc)"
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        curl \
+        libwebp-dev \
+        libmagickwand-dev; \
+    rm -rf /var/lib/apt/lists/*
 
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
-    libwebp-dev \
-    libmagickwand-dev
-RUN curl -L https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz -o imagemagick.tar.gz \
-    && tar zxf imagemagick.tar.gz \
-    && rm imagemagick.tar.gz \
-    && cd ImageMagick-$IMAGEMAGICK_VERSION \
-    && ./configure \
+RUN set -eux; \
+    curl -fsSL --retry 5 --retry-connrefused --connect-timeout 15 \
+        "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz" \
+        -o imagemagick.tar.gz; \
+    printf '%s  %s\n' "$IMAGEMAGICK_SHA256" imagemagick.tar.gz | sha256sum -c -; \
+    tar zxf imagemagick.tar.gz; \
+    rm imagemagick.tar.gz; \
+    cd "ImageMagick-$IMAGEMAGICK_VERSION"; \
+    ./configure \
         --disable-docs \
         --without-magick-plus-plus \
         --with-webp \
-        --enable-symbol-prefix \
-        --prefix=/tmp/imgck \
-        --exec-prefix=/usr/local \
-    && make -j$(nproc) \
-    && make install
-
+        --prefix=/usr/local; \
+    make -j"$(nproc)"; \
+    make install DESTDIR=/tmp/imgck; \
+    find /tmp/imgck/usr/local/lib -type f \( -name '*.a' -o -name '*.la' \) -delete
 
 
 FROM webdevops/php-apache:8.5
@@ -35,42 +42,61 @@ ARG UID=1001
 ARG GID=1001
 # https://pecl.php.net/package/imagick/3.8.1
 ARG IMAGICK_VERSION=3.8.1
+ARG IMAGICK_SHA256=3a3587c0a524c17d0dad9673a160b90cd776e836838474e173b549ed864352ee
+ARG DEBIAN_FRONTEND=noninteractive
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV MAKEFLAGS="-j$(nproc)"
-ENV APPLICATION_UID=$UID
-ENV APPLICATION_GID=$GID
+ENV APPLICATION_UID=${UID} \
+    APPLICATION_GID=${GID} \
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-COPY --chown=$UID:$GID --from=imagemagick-builder /tmp/imgck/ /usr/local/
+COPY --chown=$UID:$GID --from=imagemagick-builder /tmp/imgck/usr/local/ /usr/local/
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
 WORKDIR /tmp
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
-    jpegoptim \
-    mariadb-client \
-    webp \
-    ffmpeg \
-    libxt6 \
-    libmagickwand-dev
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        curl \
+        jpegoptim \
+        mariadb-client \
+        webp \
+        ffmpeg \
+        libxt6 \
+        libmagickwand-dev; \
+    rm -rf /var/lib/apt/lists/*
 
-RUN ldconfig /usr/local/lib \
-    && install-php-extensions gmp \
-    && curl -L https://pecl.php.net/get/imagick-${IMAGICK_VERSION}.tgz -o imagick.tgz \
-    && tar xf imagick.tgz \
-    && mkdir -p /usr/src/php/ext/imagick && mv imagick-$IMAGICK_VERSION/* /usr/src/php/ext/imagick \
-    && docker-php-ext-configure imagick \
-    && docker-php-ext-install -j$(nproc) imagick \
-    && rm imagick.tgz \
-##
-    && ldconfig /usr/local/lib \
-##
-    && apt-get purge -y libmagickwand-dev && apt-get autoremove -y --purge \
-    && docker-image-cleanup
+RUN set -eux; \
+    ldconfig /usr/local/lib; \
+    ioncube_ini=/usr/local/etc/php/conf.d/00-ioncube.ini; \
+    if [ -f "$ioncube_ini" ]; then \
+        ioncube_loader="$(awk -F= '/zend_extension/ {gsub(/[[:space:]]/, "", $2); print $2}' "$ioncube_ini")"; \
+        if [ -n "$ioncube_loader" ] && { [ ! -e "$ioncube_loader" ] || ! ldd "$ioncube_loader" >/dev/null 2>&1; }; then \
+            rm -f "$ioncube_ini"; \
+        fi; \
+    fi; \
+    export MAKEFLAGS="-j$(nproc)"; \
+    install-php-extensions gmp; \
+    curl -fsSL --retry 5 --retry-connrefused --connect-timeout 15 \
+        "https://pecl.php.net/get/imagick-${IMAGICK_VERSION}.tgz" \
+        -o imagick.tgz; \
+    printf '%s  %s\n' "$IMAGICK_SHA256" imagick.tgz | sha256sum -c -; \
+    tar zxf imagick.tgz; \
+    mkdir -p /usr/src/php/ext/imagick; \
+    mv "imagick-$IMAGICK_VERSION"/* /usr/src/php/ext/imagick; \
+    docker-php-ext-configure imagick --with-imagick=/usr/local; \
+    docker-php-ext-install -j"$(nproc)" imagick; \
+    rm -rf imagick.tgz "imagick-$IMAGICK_VERSION"; \
+    ldconfig /usr/local/lib; \
+    apt-get purge -y libmagickwand-dev; \
+    apt-get autoremove -y --purge; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    docker-image-cleanup
 
 WORKDIR /home/application
 
-RUN usermod -u $UID application \
-    && groupmod -g $UID application \
-    && chown -R application: /home/application
+RUN set -eux; \
+    usermod -u "$UID" application; \
+    groupmod -g "$GID" application; \
+    chown -R application: /home/application

--- a/README.md
+++ b/README.md
@@ -20,16 +20,20 @@ steps can diverge by version.
 
 - `latest`: integration branch for shared repo changes
 - `php80`-`php85`: actively supported version branches
-- `php73`-`php74`: legacy version branches still tracked in the manifest
+- `php73`-`php74`: deprecated/frozen version branches, kept only for critical
+  emergency maintenance
 
 FYI the `latest` branch contains the latest changes, not necessarily the latest
 PHP branch history.
 
 ## Build behavior
 
-- pushes to `latest` build the `latest` image tag
-- pushes to `phpXX` branches now build branch-specific image tags again
-- git tags such as `8.4` still build tag-specific images
+- PR branches and pushes to `latest` run build-only checks and do not publish
+  Docker images
+- pushes to `phpXX` branches publish branch-specific image tags
+- git tags such as `8.4` publish tag-specific images
+- Semaphore uses BuildKit inline cache metadata and pulls both the target tag
+  and `latest` as cache sources before building
 
 For PHP `8.5`, the Ubuntu Dockerfile now pins `imagick 3.8.1`, which is the
 first recent PECL release line compatible with PHP `8.5`.
@@ -43,8 +47,13 @@ FROM 1allen/php-apache:8.5
 RUN install-php-extensions protobuf grpc redis
 ```
 
-`imagick` remains a manual PECL build in this repository so it links against the
-custom ImageMagick installed under `/usr/local`.
+`imagick` is still bundled in the published image. This repository builds the
+pinned PECL source explicitly during the image build so the extension links
+against the custom ImageMagick installed under `/usr/local`.
+
+Source downloads for ImageMagick and PECL `imagick` are SHA-256 verified in the
+Dockerfile. When either version pin changes, update the matching checksum in the
+same change.
 
 For the common local customization case that previously looked like this:
 
@@ -74,7 +83,7 @@ Check the current repo and upstream state:
 bash scripts/repo_sync.sh status
 ```
 
-Preview shared-file drift from `latest` into all local PHP branches:
+Preview shared-file drift from `latest` into supported local PHP branches:
 
 ```bash
 bash scripts/repo_sync.sh sync-shared
@@ -86,8 +95,12 @@ Apply that shared-file sync as branch-local commits:
 bash scripts/repo_sync.sh sync-shared --apply
 ```
 
-After syncing shared files into local `phpXX` branches, push those branches so
-Semaphore triggers the corresponding branch builds.
+`sync-shared` targets supported PHP branches by default. Deprecated PHP 7
+branches are skipped unless you pass explicit branch names or use
+`--legacy`/`--all` for critical maintenance.
+
+After syncing shared files into local supported `phpXX` branches, push those
+branches so Semaphore triggers the corresponding branch image builds.
 
 Preview a new PHP branch bootstrap from `latest`:
 
@@ -113,6 +126,10 @@ Push those tag updates:
 bash scripts/tags_update.sh --apply
 ```
 
+Tag updates also target supported PHP branches by default. Deprecated PHP 7 tags
+are left in place unless you deliberately run `bash scripts/tags_update.sh
+--legacy --apply`.
+
 Run the local repository test after changing Dockerfiles, scripts, config, or
 shared documentation:
 
@@ -120,13 +137,26 @@ shared documentation:
 bash tests/repo_sync_test.sh
 ```
 
+For image behavior changes, also verify that the supported PHP branches still
+carry the required Dockerfile tooling:
+
+```bash
+bash scripts/repo_sync.sh verify-image-tooling
+```
+
 ## LLM / automation notes
 
 - Treat `config/php-branches.conf` as the source of truth for supported branches
   and shared files.
 - Keep `AGENTS.md` and `docs/maintenance.md` in sync with Dockerfile behavior.
+- Keep `.dockerignore` in shared-file sync so CI build contexts stay small on
+  every PHP branch.
+- Preserve SHA-256 verification for ImageMagick and PECL `imagick` downloads.
 - Put shared maintenance changes on `latest` first, then use
   `bash scripts/repo_sync.sh sync-shared` to preview branch drift.
+- Treat `php73` and `php74` as deprecated/frozen. Do not sync shared files,
+  update tags, or refresh Dockerfile behavior there unless the change is a
+  critical emergency fix.
 - Use `bootstrap-version` when upstream adds a new PHP minor tag so the repo has
   a predictable, reviewable starting point for that branch.
 - Remote checks in `status` are advisory; the manifest stays authoritative if a

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ bash scripts/repo_sync.sh sync-shared --apply
 ```
 
 `sync-shared` targets supported PHP branches by default. Deprecated PHP 7
-branches are skipped unless you pass explicit branch names or use
-`--legacy`/`--all` for critical maintenance.
+branches are skipped unless you pass explicit branch names for critical
+maintenance.
 
 After syncing shared files into local supported `phpXX` branches, push those
 branches so Semaphore triggers the corresponding branch image builds.
@@ -127,8 +127,8 @@ bash scripts/tags_update.sh --apply
 ```
 
 Tag updates also target supported PHP branches by default. Deprecated PHP 7 tags
-are left in place unless you deliberately run `bash scripts/tags_update.sh
---legacy --apply`.
+are left in place unless you deliberately name those branches, for example
+`bash scripts/tags_update.sh --apply php73 php74`.
 
 Run the local repository test after changing Dockerfiles, scripts, config, or
 shared documentation:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ PHP branch history.
 - Semaphore uses BuildKit inline cache metadata and pulls both the target tag
   and `latest` as cache sources before building
 
+The Docker build and publish logic lives in `scripts/ci_docker_build.sh` so CI
+configuration stays thin. Other CI providers can call the same script by setting
+`CI_GIT_BRANCH` and `CI_GIT_TAG` from their native branch/tag variables.
+
 For PHP `8.5`, the Ubuntu Dockerfile now pins `imagick 3.8.1`, which is the
 first recent PECL release line compatible with PHP `8.5`.
 

--- a/config/php-branches.conf
+++ b/config/php-branches.conf
@@ -15,7 +15,6 @@ SUPPORTED_PHP_BRANCHES=(
 )
 
 LEGACY_PHP_BRANCHES=(
-    # Deprecated/frozen. Keep available for critical emergency maintenance only.
     php73
     php74
 )

--- a/config/php-branches.conf
+++ b/config/php-branches.conf
@@ -15,12 +15,14 @@ SUPPORTED_PHP_BRANCHES=(
 )
 
 LEGACY_PHP_BRANCHES=(
+    # Deprecated/frozen. Keep available for critical emergency maintenance only.
     php73
     php74
 )
 
 SHARED_FILES=(
     AGENTS.md
+    .dockerignore
     .semaphore/semaphore.yml
     README.md
     config/php-branches.conf

--- a/config/php-branches.conf
+++ b/config/php-branches.conf
@@ -26,6 +26,7 @@ SHARED_FILES=(
     README.md
     config/php-branches.conf
     docs/maintenance.md
+    scripts/ci_docker_build.sh
     scripts/repo_sync.sh
     scripts/tags_update.sh
 )

--- a/docs/adr/0001-build-only-latest-branch.md
+++ b/docs/adr/0001-build-only-latest-branch.md
@@ -1,0 +1,8 @@
+# Build Only From Latest Branch
+
+The `latest` branch is the integration branch for shared maintenance changes,
+not a consumer PHP version line. CI should build PR branches and `latest` to
+prove the image still builds, but Docker Hub publishing belongs to `phpXX`
+branches and semver git tags so published image names stay tied to the
+project's existing branch and tag model.
+

--- a/docs/adr/0002-stage-imagemagick-with-destdir.md
+++ b/docs/adr/0002-stage-imagemagick-with-destdir.md
@@ -1,0 +1,8 @@
+# Stage ImageMagick With DESTDIR
+
+ImageMagick should be configured with its runtime prefix as `/usr/local` and
+installed into a temporary staging root with `make install DESTDIR=/tmp/imgck`.
+This keeps the copied artifact paths aligned with their runtime location while
+still allowing the final image to copy only the staged `/usr/local` tree from
+the builder stage.
+

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -22,24 +22,40 @@ As of 2026-06-24:
   `Dockerfile.ubuntu`.
 - ImageMagick is pinned to `7.1.2-26`.
 - PECL `imagick` is pinned to `3.8.1`.
+- ImageMagick and PECL `imagick` source archives are verified with SHA-256
+  checksums in `Dockerfile.ubuntu`.
 - `install-php-extensions` is copied from
-  `ghcr.io/mlocati/php-extension-installer:latest` into `/usr/local/bin`.
+  `mlocati/php-extension-installer:latest` into `/usr/local/bin`.
+- CI enables BuildKit inline cache metadata and uses both the target image tag
+  and `latest` as cache sources. PR branches and `latest` are build-only;
+  Docker Hub publishing is reserved for `phpXX` branches and git tags.
+- `.dockerignore` intentionally keeps repo docs, tests, scripts, local agent
+  state, and Git metadata out of the Docker build context because the image does
+  not copy files from the repository.
+- PHP 7 branches (`php73`, `php74`) are deprecated/frozen. They remain available
+  for existing consumers, but normal shared-file sync, Dockerfile behavior
+  updates, and tag movement should skip them unless a critical emergency fix
+  requires an explicit opt-in.
 
-## Why Imagick Is Manual
+## Why Imagick Is Built Explicitly
 
-The final image needs `imagick` to build against the custom ImageMagick copied
-from the `imagemagick-builder` stage into `/usr/local`. The mlocati installer
-knows how to install `imagick`, but on Debian it also manages distro
-ImageMagick packages. That is useful for default images, but it can hide whether
-the extension linked to the custom `/usr/local` ImageMagick build.
+The final image must continue to bundle `imagick`; it is one of the core
+features of this repository. The build installs it from pinned PECL source so
+it links against the custom ImageMagick copied from the `imagemagick-builder`
+stage into `/usr/local`. The mlocati installer knows how to install `imagick`,
+but on Debian it also manages distro ImageMagick packages. That is useful for
+default images, but it can hide whether the extension linked to the custom
+`/usr/local` ImageMagick build.
 
 For that reason:
 
 - use `install-php-extensions` for ordinary extensions such as `gmp`,
   `protobuf`, `grpc`, and `redis`;
-- keep PECL `imagick` installation explicit unless you verify the linked
-  libraries with `ldd`;
+- keep `imagick` bundled in this image and keep its PECL source build explicit
+  unless you verify the linked libraries with `ldd`;
 - run `ldconfig /usr/local/lib` before and after compiling `imagick`.
+- configure `imagick` with `--with-imagick=/usr/local` so it uses the copied
+  custom ImageMagick build instead of Debian's ImageMagick packages.
 
 Useful verification commands after a build:
 
@@ -74,12 +90,23 @@ curl -fsSL 'https://hub.docker.com/v2/namespaces/webdevops/repositories/php-apac
   | grep -E '^[0-9]+\.[0-9]+$'
 ```
 
+Checksum update helpers for the currently pinned source archives:
+
+```bash
+IMAGEMAGICK_VERSION=7.1.2-26
+IMAGICK_VERSION=3.8.1
+curl -fsSL "https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz" \
+  | shasum -a 256
+curl -fsSL "https://pecl.php.net/get/imagick-${IMAGICK_VERSION}.tgz" \
+  | shasum -a 256
+```
+
 After updating versions, run:
 
 ```bash
 bash tests/repo_sync_test.sh
 bash scripts/repo_sync.sh verify-image-tooling
-docker build --pull -f Dockerfile.ubuntu -t php-apache:local .
+DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile.ubuntu -t php-apache:local .
 ```
 
 If the local Docker build is not practical, still run the shell test and review
@@ -117,8 +144,7 @@ RUN install-php-extensions grpc redis protobuf
 
 The installer resolves build packages, installs the PECL-backed extensions, and
 enables them. Use this for downstream `grpc`, `redis`, and `protobuf` unless
-you are debugging a PECL-specific failure and need to reproduce the manual
-steps.
+you are debugging a PECL-specific failure and need to reproduce installer steps.
 
 Pin extension versions downstream when reproducibility matters:
 
@@ -135,6 +161,7 @@ the downstream Dockerfile so this base image stays broadly reusable.
 
 1. Make shared changes on `latest`.
 2. Confirm shared files are listed in `config/php-branches.conf`.
+   `.dockerignore` is shared so build-context hygiene stays consistent.
 3. If `Dockerfile.ubuntu` changes, apply the same Dockerfile behavior to each
    `phpXX` branch intentionally. `Dockerfile.ubuntu` is not a shared file
    because each branch can carry a different `FROM webdevops/php-apache:X.Y`
@@ -152,7 +179,7 @@ the downstream Dockerfile so this base image stays broadly reusable.
    tracked but are not part of the default supported-image guarantee; check
    them explicitly with `bash scripts/repo_sync.sh verify-image-tooling --legacy`
    when changing legacy images.
-5. Preview branch drift:
+5. Preview branch drift across supported PHP branches:
 
    ```bash
    bash scripts/repo_sync.sh sync-shared
@@ -164,7 +191,16 @@ the downstream Dockerfile so this base image stays broadly reusable.
    bash scripts/repo_sync.sh sync-shared --apply
    ```
 
-7. Push the updated PHP branches so Semaphore builds branch-specific image tags.
+   Deprecated PHP 7 branches are skipped by default. For a critical emergency
+   fix only, target them explicitly, for example:
+
+   ```bash
+   bash scripts/repo_sync.sh sync-shared --legacy
+   bash scripts/repo_sync.sh sync-shared --legacy --apply
+   ```
+
+7. Push the updated PHP branches so Semaphore builds and publishes
+   branch-specific image tags.
 8. Preview and apply Docker tag updates when users consume semver image tags
    such as `1allen/php-apache:8.2`:
 
@@ -172,3 +208,38 @@ the downstream Dockerfile so this base image stays broadly reusable.
    bash scripts/tags_update.sh
    bash scripts/tags_update.sh --apply
    ```
+
+   This updates supported PHP tags only. Deprecated PHP 7 tags are intentionally
+   left where they are unless you run `bash scripts/tags_update.sh --legacy
+   --apply` for a critical emergency fix.
+
+## Reviewing Multi-Branch Changes
+
+Keep `latest` as the main review surface for shared files. Review branch-local
+Dockerfile changes separately because each `phpXX` branch can preserve a
+different base PHP minor or extension compatibility pin.
+
+Useful local review commands:
+
+```bash
+git status --short --branch
+git diff --stat
+git diff
+for branch in php80 php81 php82 php83 php84 php85; do
+  git log --oneline -1 "$branch"
+  git diff "origin/$branch..$branch" -- Dockerfile.ubuntu
+done
+```
+
+Before pushing, run:
+
+```bash
+bash tests/repo_sync_test.sh
+bash scripts/repo_sync.sh verify-image-tooling
+```
+
+Open a PR against `latest` first for shared-file review. Semaphore builds the
+PR and the eventual `latest` merge without publishing images. After review,
+push the supported `phpXX` branches that carry Dockerfile commits so Semaphore
+publishes branch-specific image tags. Leave `php73` and `php74` untouched unless
+the change is a critical emergency fix.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -29,6 +29,10 @@ As of 2026-06-24:
 - CI enables BuildKit inline cache metadata and uses both the target image tag
   and `latest` as cache sources. PR branches and `latest` are build-only;
   Docker Hub publishing is reserved for `phpXX` branches and git tags.
+- CI declaration files call `scripts/ci_docker_build.sh` instead of embedding
+  the Docker build and publish shell logic. New CI providers should map their
+  native branch/tag variables to `CI_GIT_BRANCH` and `CI_GIT_TAG` before calling
+  that script.
 - `.dockerignore` intentionally keeps repo docs, tests, scripts, local agent
   state, and Git metadata out of the Docker build context because the image does
   not copy files from the repository.
@@ -122,6 +126,13 @@ If the local Docker CLI falls back to the legacy builder, use Buildx instead:
 
 ```bash
 docker buildx build --pull -f Dockerfile.ubuntu .
+```
+
+To exercise the same build decision logic used by CI, run the script directly:
+
+```bash
+CI_GIT_BRANCH=latest bash scripts/ci_docker_build.sh
+CI_GIT_BRANCH=php85 DOCKER_PASSWORD=... bash scripts/ci_docker_build.sh
 ```
 
 If the local Docker build is not practical, still run the shell test and review

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -25,7 +25,7 @@ As of 2026-06-24:
 - ImageMagick and PECL `imagick` source archives are verified with SHA-256
   checksums in `Dockerfile.ubuntu`.
 - `install-php-extensions` is copied from
-  `mlocati/php-extension-installer:latest` into `/usr/local/bin`.
+  `ghcr.io/mlocati/php-extension-installer:latest` into `/usr/local/bin`.
 - CI enables BuildKit inline cache metadata and uses both the target image tag
   and `latest` as cache sources. PR branches and `latest` are build-only;
   Docker Hub publishing is reserved for `phpXX` branches and git tags.
@@ -66,6 +66,15 @@ docker run --rm php-apache:local sh -lc 'ldd "$(php-config --extension-dir)/imag
 docker run --rm php-apache:local command -v install-php-extensions
 ```
 
+## Base-Image Compatibility Cleanup
+
+The upstream `webdevops/php-apache` base can carry optional configuration for
+components that are not usable in a derived image after package and extension
+updates. The Dockerfile removes `/usr/local/etc/php/conf.d/00-ioncube.ini` only
+when it points to a missing or unloadable ionCube loader, because that inherited
+configuration causes PHP startup warnings even though ionCube is not part of
+this image's maintained feature set.
+
 ## Updating Upstreams
 
 Check these sources before changing pins:
@@ -105,12 +114,21 @@ After updating versions, run:
 
 ```bash
 bash tests/repo_sync_test.sh
-bash scripts/repo_sync.sh verify-image-tooling
+bash scripts/repo_sync.sh verify-image-tooling latest
 DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile.ubuntu -t php-apache:local .
 ```
 
+If the local Docker CLI falls back to the legacy builder, use Buildx instead:
+
+```bash
+docker buildx build --pull -f Dockerfile.ubuntu .
+```
+
 If the local Docker build is not practical, still run the shell test and review
-the Dockerfile diff carefully. The real build happens in Semaphore.
+the Dockerfile diff carefully. The real build happens in Semaphore. After
+propagating Dockerfile behavior to supported PHP branches, run
+`bash scripts/repo_sync.sh verify-image-tooling` before pushing those branch
+updates.
 
 ## Downstream Images
 
@@ -166,8 +184,16 @@ the downstream Dockerfile so this base image stays broadly reusable.
    `phpXX` branch intentionally. `Dockerfile.ubuntu` is not a shared file
    because each branch can carry a different `FROM webdevops/php-apache:X.Y`
    and extension compatibility pin.
-4. Verify every committed branch Dockerfile still exposes the expected
-   downstream image tooling for supported branches:
+4. For a `latest`-only PR, verify the maintained Dockerfile on the review
+   branch:
+
+   ```bash
+   bash scripts/repo_sync.sh verify-image-tooling latest
+   ```
+
+   After propagating Dockerfile behavior to supported PHP branches, verify every
+   committed branch Dockerfile still exposes the expected downstream image
+   tooling:
 
    ```bash
    bash scripts/repo_sync.sh verify-image-tooling
@@ -175,10 +201,10 @@ the downstream Dockerfile so this base image stays broadly reusable.
 
    This guard exists because documentation on `latest` can advertise a
    downstream customization feature before the semver branches actually include
-   the Dockerfile support for it. Legacy branches `php73` and `php74` are
-   tracked but are not part of the default supported-image guarantee; check
-   them explicitly with `bash scripts/repo_sync.sh verify-image-tooling --legacy`
-   when changing legacy images.
+   the Dockerfile support for it. PHP 7 branches `php73` and `php74` are tracked
+   but are not part of the default supported-image guarantee; check them
+   explicitly with `bash scripts/repo_sync.sh verify-image-tooling php73 php74`
+   when changing those images.
 5. Preview branch drift across supported PHP branches:
 
    ```bash
@@ -195,8 +221,8 @@ the downstream Dockerfile so this base image stays broadly reusable.
    fix only, target them explicitly, for example:
 
    ```bash
-   bash scripts/repo_sync.sh sync-shared --legacy
-   bash scripts/repo_sync.sh sync-shared --legacy --apply
+   bash scripts/repo_sync.sh sync-shared php73 php74
+   bash scripts/repo_sync.sh sync-shared --apply php73 php74
    ```
 
 7. Push the updated PHP branches so Semaphore builds and publishes
@@ -210,8 +236,12 @@ the downstream Dockerfile so this base image stays broadly reusable.
    ```
 
    This updates supported PHP tags only. Deprecated PHP 7 tags are intentionally
-   left where they are unless you run `bash scripts/tags_update.sh --legacy
-   --apply` for a critical emergency fix.
+   left where they are unless you name those branches explicitly for a critical
+   emergency fix:
+
+   ```bash
+   bash scripts/tags_update.sh --apply php73 php74
+   ```
 
 ## Reviewing Multi-Branch Changes
 
@@ -235,7 +265,7 @@ Before pushing, run:
 
 ```bash
 bash tests/repo_sync_test.sh
-bash scripts/repo_sync.sh verify-image-tooling
+bash scripts/repo_sync.sh verify-image-tooling latest
 ```
 
 Open a PR against `latest` first for shared-file review. Semaphore builds the

--- a/scripts/ci_docker_build.sh
+++ b/scripts/ci_docker_build.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DOCKERFILE_PATH="${DOCKERFILE_PATH:-Dockerfile.ubuntu}"
+BUILD_CONTEXT="${BUILD_CONTEXT:-.}"
+DOCKER_USERNAME="${DOCKER_USERNAME:-1allen}"
+IMAGE_NAME="${IMAGE_NAME:-php-apache}"
+BUILDER_IMAGE="${BUILDER_IMAGE:-spritsail/debian-builder:latest}"
+CI_GIT_BRANCH="${CI_GIT_BRANCH:-${SEMAPHORE_GIT_BRANCH:-${CIRCLE_BRANCH:-}}}"
+CI_GIT_TAG="${CI_GIT_TAG:-${SEMAPHORE_GIT_TAG_NAME:-${CIRCLE_TAG:-}}}"
+export DOCKER_BUILDKIT="${DOCKER_BUILDKIT:-1}"
+
+if [[ -z "$CI_GIT_BRANCH" && "${GITHUB_REF_TYPE:-}" == "branch" ]]; then
+    CI_GIT_BRANCH="${GITHUB_REF_NAME:-}"
+fi
+
+if [[ -z "$CI_GIT_TAG" && "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+    CI_GIT_TAG="${GITHUB_REF_NAME:-}"
+fi
+
+publish_image=0
+publish_tag=""
+cache_from_args=()
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+docker_pull_cache_source() {
+    local image_ref="$1"
+
+    docker pull "$image_ref" || true
+}
+
+if [[ -n "$CI_GIT_TAG" ]]; then
+    publish_tag="$CI_GIT_TAG"
+    publish_image=1
+elif [[ "$CI_GIT_BRANCH" =~ ^php[0-9][0-9]$ ]]; then
+    publish_tag="$CI_GIT_BRANCH"
+    publish_image=1
+fi
+
+cd "$ROOT_DIR"
+
+if [[ "$publish_image" -eq 1 ]]; then
+    docker_pull_cache_source "$DOCKER_USERNAME/$IMAGE_NAME:$publish_tag"
+    cache_from_args+=(--cache-from "$DOCKER_USERNAME/$IMAGE_NAME:$publish_tag")
+fi
+
+docker_pull_cache_source "$DOCKER_USERNAME/$IMAGE_NAME:latest"
+docker_pull_cache_source "$BUILDER_IMAGE"
+cache_from_args+=(--cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest")
+cache_from_args+=(--cache-from "$BUILDER_IMAGE")
+
+build_args=(
+    --pull
+    --build-arg BUILDKIT_INLINE_CACHE=1
+    "${cache_from_args[@]}"
+    -f "$DOCKERFILE_PATH"
+)
+
+if [[ "$publish_image" -eq 1 ]]; then
+    build_args+=(-t "$IMAGE_NAME:$publish_tag")
+fi
+
+docker build "${build_args[@]}" "$BUILD_CONTEXT"
+
+if [[ "$publish_image" -eq 1 ]]; then
+    [[ -n "${DOCKER_PASSWORD:-}" ]] || die "DOCKER_PASSWORD is required to publish $DOCKER_USERNAME/$IMAGE_NAME:$publish_tag."
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+    docker tag "$IMAGE_NAME:$publish_tag" "$DOCKER_USERNAME/$IMAGE_NAME:$publish_tag"
+    docker push "$DOCKER_USERNAME/$IMAGE_NAME:$publish_tag"
+else
+    echo "Build-only branch: not publishing image"
+fi

--- a/scripts/repo_sync.sh
+++ b/scripts/repo_sync.sh
@@ -25,8 +25,8 @@ usage() {
     cat <<'EOF'
 Usage:
   bash scripts/repo_sync.sh status
-  bash scripts/repo_sync.sh sync-shared [--apply] [--legacy|--all] [branch...]
-  bash scripts/repo_sync.sh verify-image-tooling [--legacy|--all] [branch...]
+  bash scripts/repo_sync.sh sync-shared [--apply] [branch...]
+  bash scripts/repo_sync.sh verify-image-tooling [branch...]
   bash scripts/repo_sync.sh bootstrap-version php85 [--apply]
 
 Commands:
@@ -34,12 +34,12 @@ Commands:
                      and advisory upstream Docker Hub tags.
   sync-shared        Sync shared files from the source branch into local PHP branches.
                      Dry-run by default. Targets supported branches only unless
-                     explicit branches, --legacy, or --all are provided.
+                     explicit branches are provided.
                      Use --apply to create branch-local commits.
   verify-image-tooling
                      Check that supported branch Dockerfiles include the image
                      tooling expected by downstream custom images.
-                     Use --legacy to include legacy branches or --all for both.
+                     Pass branch names explicitly to check a narrower or older set.
   bootstrap-version  Create a new local PHP branch from the source branch and rewrite
                      Dockerfile.ubuntu to the requested PHP version. Dry-run by default.
 EOF
@@ -222,8 +222,6 @@ status_command() {
 
 sync_shared_command() {
     local apply=0
-    local include_legacy=0
-    local include_supported=1
     local message="chore: sync shared repo files from ${BOOTSTRAP_SOURCE_BRANCH}"
     local target_branches=()
     local source_worktree=""
@@ -238,13 +236,8 @@ sync_shared_command() {
             --apply)
                 apply=1
                 ;;
-            --legacy)
-                include_supported=0
-                include_legacy=1
-                ;;
-            --all)
-                include_supported=1
-                include_legacy=1
+            -*)
+                die "Unknown sync-shared option: $1"
                 ;;
             *)
                 target_branches+=("$1")
@@ -254,13 +247,7 @@ sync_shared_command() {
     done
 
     if [[ ${#target_branches[@]} -eq 0 ]]; then
-        if [[ $include_supported -eq 1 ]]; then
-            target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")
-        fi
-
-        if [[ $include_legacy -eq 1 ]]; then
-            target_branches+=("${LEGACY_PHP_BRANCHES[@]}")
-        fi
+        target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")
     fi
 
     prepare_temp_root
@@ -325,8 +312,6 @@ sync_shared_command() {
 
 verify_image_tooling_command() {
     local target_branches=()
-    local include_legacy=0
-    local include_supported=1
     local branch
     local dockerfile_content
     local marker
@@ -334,7 +319,7 @@ verify_image_tooling_command() {
     local failed=0
     local current
     local required_markers=(
-        'FROM mlocati/php-extension-installer:latest AS php-extension-installer'
+        'FROM ghcr.io/mlocati/php-extension-installer:latest AS php-extension-installer'
         'COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/'
         'COPY --chown=$UID:$GID --from=imagemagick-builder /tmp/imgck/usr/local/ /usr/local/'
         'install-php-extensions gmp'
@@ -345,13 +330,8 @@ verify_image_tooling_command() {
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --legacy)
-                include_supported=0
-                include_legacy=1
-                ;;
-            --all)
-                include_supported=1
-                include_legacy=1
+            -*)
+                die "Unknown verify-image-tooling option: $1"
                 ;;
             *)
                 target_branches+=("$1")
@@ -362,14 +342,7 @@ verify_image_tooling_command() {
 
     if [[ ${#target_branches[@]} -eq 0 ]]; then
         target_branches+=("$BOOTSTRAP_SOURCE_BRANCH")
-
-        if [[ $include_supported -eq 1 ]]; then
-            target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")
-        fi
-
-        if [[ $include_legacy -eq 1 ]]; then
-            target_branches+=("${LEGACY_PHP_BRANCHES[@]}")
-        fi
+        target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")
     fi
 
     print_section "Image tooling branches:" "${target_branches[@]}"

--- a/scripts/repo_sync.sh
+++ b/scripts/repo_sync.sh
@@ -25,7 +25,7 @@ usage() {
     cat <<'EOF'
 Usage:
   bash scripts/repo_sync.sh status
-  bash scripts/repo_sync.sh sync-shared [--apply] [branch...]
+  bash scripts/repo_sync.sh sync-shared [--apply] [--legacy|--all] [branch...]
   bash scripts/repo_sync.sh verify-image-tooling [--legacy|--all] [branch...]
   bash scripts/repo_sync.sh bootstrap-version php85 [--apply]
 
@@ -33,7 +33,9 @@ Commands:
   status             Show configured branches, local/remote branches, shared files,
                      and advisory upstream Docker Hub tags.
   sync-shared        Sync shared files from the source branch into local PHP branches.
-                     Dry-run by default. Use --apply to create branch-local commits.
+                     Dry-run by default. Targets supported branches only unless
+                     explicit branches, --legacy, or --all are provided.
+                     Use --apply to create branch-local commits.
   verify-image-tooling
                      Check that supported branch Dockerfiles include the image
                      tooling expected by downstream custom images.
@@ -70,6 +72,22 @@ branch_exists_local() {
 
 branch_exists_remote() {
     git -C "$ROOT_DIR" show-ref --verify --quiet "refs/remotes/origin/$1"
+}
+
+current_branch() {
+    git -C "$ROOT_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true
+}
+
+use_worktree_as_source_branch() {
+    local requested_branch="$1"
+    local current="$2"
+
+    [[ "$requested_branch" == "$BOOTSTRAP_SOURCE_BRANCH" ]] || return 1
+    [[ -n "$current" ]] || return 1
+    [[ "$current" == "$BOOTSTRAP_SOURCE_BRANCH" ]] && return 0
+    branch_in_list "$current" "${SUPPORTED_PHP_BRANCHES[@]}" "${LEGACY_PHP_BRANCHES[@]}" && return 1
+
+    return 0
 }
 
 require_clean_worktree() {
@@ -121,7 +139,7 @@ load_upstream_branches() {
     fi
 
     local response
-    if ! response="$(curl -fsSL "$UPSTREAM_IMAGE_TAGS_URL" 2>/dev/null)"; then
+    if ! response="$(curl -fsSL --retry 3 --retry-connrefused --connect-timeout 15 "$UPSTREAM_IMAGE_TAGS_URL" 2>/dev/null)"; then
         return
     fi
 
@@ -204,6 +222,8 @@ status_command() {
 
 sync_shared_command() {
     local apply=0
+    local include_legacy=0
+    local include_supported=1
     local message="chore: sync shared repo files from ${BOOTSTRAP_SOURCE_BRANCH}"
     local target_branches=()
     local source_worktree=""
@@ -218,6 +238,14 @@ sync_shared_command() {
             --apply)
                 apply=1
                 ;;
+            --legacy)
+                include_supported=0
+                include_legacy=1
+                ;;
+            --all)
+                include_supported=1
+                include_legacy=1
+                ;;
             *)
                 target_branches+=("$1")
                 ;;
@@ -226,9 +254,13 @@ sync_shared_command() {
     done
 
     if [[ ${#target_branches[@]} -eq 0 ]]; then
-        while IFS= read -r branch; do
-            [[ -n "$branch" ]] && target_branches+=("$branch")
-        done < <(all_configured_branches)
+        if [[ $include_supported -eq 1 ]]; then
+            target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")
+        fi
+
+        if [[ $include_legacy -eq 1 ]]; then
+            target_branches+=("${LEGACY_PHP_BRANCHES[@]}")
+        fi
     fi
 
     prepare_temp_root
@@ -300,10 +332,13 @@ verify_image_tooling_command() {
     local marker
     local missing_markers=()
     local failed=0
+    local current
     local required_markers=(
-        'FROM ghcr.io/mlocati/php-extension-installer:latest AS php-extension-installer'
+        'FROM mlocati/php-extension-installer:latest AS php-extension-installer'
         'COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/'
+        'COPY --chown=$UID:$GID --from=imagemagick-builder /tmp/imgck/usr/local/ /usr/local/'
         'install-php-extensions gmp'
+        'docker-php-ext-configure imagick --with-imagick=/usr/local'
         'https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz'
         'https://pecl.php.net/get/imagick-${IMAGICK_VERSION}.tgz'
     )
@@ -338,6 +373,7 @@ verify_image_tooling_command() {
     fi
 
     print_section "Image tooling branches:" "${target_branches[@]}"
+    current="$(current_branch)"
 
     for branch in "${target_branches[@]}"; do
         missing_markers=()
@@ -348,7 +384,13 @@ verify_image_tooling_command() {
             continue
         fi
 
-        if ! dockerfile_content="$(git -C "$ROOT_DIR" show "$branch:Dockerfile.ubuntu" 2>/dev/null)"; then
+        if [[ "$branch" == "$current" ]] || use_worktree_as_source_branch "$branch" "$current"; then
+            if ! dockerfile_content="$(cat "$ROOT_DIR/Dockerfile.ubuntu" 2>/dev/null)"; then
+                echo "$branch: missing Dockerfile.ubuntu."
+                failed=1
+                continue
+            fi
+        elif ! dockerfile_content="$(git -C "$ROOT_DIR" show "$branch:Dockerfile.ubuntu" 2>/dev/null)"; then
             echo "$branch: missing Dockerfile.ubuntu."
             failed=1
             continue

--- a/scripts/tags_update.sh
+++ b/scripts/tags_update.sh
@@ -7,11 +7,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/config/php-branches.conf"
 
 DRY_RUN=1
+INCLUDE_LEGACY=0
 
 convert_branch_to_tag() {
     local branch_name="$1"
     local version="${branch_name#php}"
-    echo "${version:0:1}.${version:1:1}"
+    echo "${version:0:1}.${version:1}"
 }
 
 run_cmd() {
@@ -26,11 +27,14 @@ run_cmd() {
 usage() {
     cat <<'EOF'
 Usage:
-  bash scripts/tags_update.sh
-  bash scripts/tags_update.sh --apply
+  bash scripts/tags_update.sh [--legacy]
+  bash scripts/tags_update.sh --apply [--legacy]
 
-By default this prints the tag actions it would take for the configured PHP
-branches that exist on origin. Use --apply to push the tag updates.
+By default this prints the tag actions it would take for supported PHP branches
+that exist on origin. Use --apply to push the tag updates.
+
+Deprecated PHP 7 branches are intentionally skipped unless --legacy is provided
+for critical maintenance.
 EOF
 }
 
@@ -38,6 +42,9 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --apply)
             DRY_RUN=0
+            ;;
+        --legacy)
+            INCLUDE_LEGACY=1
             ;;
         -h|--help|help)
             usage
@@ -54,7 +61,12 @@ done
 
 git -C "$ROOT_DIR" fetch --all --tags
 
-for branch in "${SUPPORTED_PHP_BRANCHES[@]}" "${LEGACY_PHP_BRANCHES[@]}"; do
+target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")
+if [[ "$INCLUDE_LEGACY" -eq 1 ]]; then
+    target_branches+=("${LEGACY_PHP_BRANCHES[@]}")
+fi
+
+for branch in "${target_branches[@]}"; do
     if ! git -C "$ROOT_DIR" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
         echo "Skipping $branch: missing origin/$branch"
         continue

--- a/scripts/tags_update.sh
+++ b/scripts/tags_update.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/config/php-branches.conf"
 
 DRY_RUN=1
-INCLUDE_LEGACY=0
+target_branches=()
 
 convert_branch_to_tag() {
     local branch_name="$1"
@@ -24,17 +24,19 @@ run_cmd() {
     "$@"
 }
 
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
 usage() {
     cat <<'EOF'
 Usage:
-  bash scripts/tags_update.sh [--legacy]
-  bash scripts/tags_update.sh --apply [--legacy]
+  bash scripts/tags_update.sh [--apply] [branch...]
 
 By default this prints the tag actions it would take for supported PHP branches
-that exist on origin. Use --apply to push the tag updates.
-
-Deprecated PHP 7 branches are intentionally skipped unless --legacy is provided
-for critical maintenance.
+that exist on origin. Pass branch names explicitly for a narrower or older set.
+Use --apply to push the tag updates.
 EOF
 }
 
@@ -43,17 +45,17 @@ while [[ $# -gt 0 ]]; do
         --apply)
             DRY_RUN=0
             ;;
-        --legacy)
-            INCLUDE_LEGACY=1
-            ;;
         -h|--help|help)
             usage
             exit 0
             ;;
-        *)
+        -*)
             echo "Unknown option: $1" >&2
             usage >&2
             exit 1
+            ;;
+        *)
+            target_branches+=("$1")
             ;;
     esac
     shift
@@ -61,12 +63,13 @@ done
 
 git -C "$ROOT_DIR" fetch --all --tags
 
-target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")
-if [[ "$INCLUDE_LEGACY" -eq 1 ]]; then
-    target_branches+=("${LEGACY_PHP_BRANCHES[@]}")
+if [[ ${#target_branches[@]} -eq 0 ]]; then
+    target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")
 fi
 
 for branch in "${target_branches[@]}"; do
+    [[ "$branch" =~ ^php[0-9][0-9]$ ]] || die "Branch must look like php85: $branch"
+
     if ! git -C "$ROOT_DIR" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
         echo "Skipping $branch: missing origin/$branch"
         continue

--- a/tests/repo_sync_test.sh
+++ b/tests/repo_sync_test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_PATH="$ROOT_DIR/scripts/repo_sync.sh"
 TAGS_SCRIPT_PATH="$ROOT_DIR/scripts/tags_update.sh"
+CI_DOCKER_BUILD_SCRIPT_PATH="$ROOT_DIR/scripts/ci_docker_build.sh"
 MANIFEST_PATH="$ROOT_DIR/config/php-branches.conf"
 DOCKERFILE_PATH="$ROOT_DIR/Dockerfile.ubuntu"
 SEMAPHORE_PATH="$ROOT_DIR/.semaphore/semaphore.yml"
@@ -44,6 +45,11 @@ assert_file_contains() {
     exit 1
 }
 
+[[ -x "$CI_DOCKER_BUILD_SCRIPT_PATH" ]] || {
+    echo "Missing executable CI Docker build script: $CI_DOCKER_BUILD_SCRIPT_PATH" >&2
+    exit 1
+}
+
 status_output="$(bash "$SCRIPT_PATH" status)"
 assert_contains "$status_output" "Configured PHP branches:"
 assert_contains "$status_output" "php85"
@@ -51,6 +57,7 @@ assert_contains "$status_output" ".semaphore/semaphore.yml"
 assert_contains "$status_output" ".dockerignore"
 assert_contains "$status_output" "AGENTS.md"
 assert_contains "$status_output" "docs/maintenance.md"
+assert_contains "$status_output" "scripts/ci_docker_build.sh"
 
 dry_run_output="$(bash "$SCRIPT_PATH" bootstrap-version php85)"
 assert_contains "$dry_run_output" "php85"
@@ -80,13 +87,9 @@ assert_file_contains "$DOCKERFILE_PATH" 'ldd "$ioncube_loader"'
 assert_file_contains "$DOCKERFILE_PATH" 'groupmod -g "$GID" application'
 assert_file_contains "$SEMAPHORE_PATH" "when: \"branch = 'master'\""
 assert_file_contains "$SEMAPHORE_PATH" 'DOCKER_BUILDKIT'
-assert_file_contains "$SEMAPHORE_PATH" 'BUILDKIT_INLINE_CACHE=1'
-assert_file_contains "$SEMAPHORE_PATH" '--cache-from $DOCKER_USERNAME/$IMAGE_NAME:latest'
-assert_file_contains "$SEMAPHORE_PATH" 'PUBLISH_IMAGE=0'
-assert_file_contains "$SEMAPHORE_PATH" 'PUBLISH_TAG=""'
-assert_file_contains "$SEMAPHORE_PATH" "grep -Eq '^php[0-9][0-9]$'"
-assert_file_contains "$SEMAPHORE_PATH" 'docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu .'
-assert_file_contains "$SEMAPHORE_PATH" 'Build-only branch: not publishing image'
+assert_file_contains "$SEMAPHORE_PATH" 'CI_GIT_BRANCH="${SEMAPHORE_GIT_BRANCH:-}"'
+assert_file_contains "$SEMAPHORE_PATH" 'CI_GIT_TAG="${SEMAPHORE_GIT_TAG_NAME:-}"'
+assert_file_contains "$SEMAPHORE_PATH" 'bash scripts/ci_docker_build.sh'
 
 if grep -q "branch =~ '^php'" "$SEMAPHORE_PATH"; then
     echo "Expected Semaphore config to build phpXX branches." >&2
@@ -100,6 +103,14 @@ assert_file_contains "$SCRIPT_PATH" 'curl -fsSL --retry 3 --retry-connrefused --
 assert_file_contains "$SCRIPT_PATH" 'verify-image-tooling'
 assert_file_contains "$SCRIPT_PATH" 'sync-shared [--apply] [branch...]'
 assert_file_contains "$SCRIPT_PATH" 'target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'BUILDKIT_INLINE_CACHE=1'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" '--cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'CI_GIT_BRANCH="${CI_GIT_BRANCH:-${SEMAPHORE_GIT_BRANCH:-${CIRCLE_BRANCH:-}}}"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'CI_GIT_TAG="${CI_GIT_TAG:-${SEMAPHORE_GIT_TAG_NAME:-${CIRCLE_TAG:-}}}"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'GITHUB_REF_TYPE:-}" == "branch"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'GITHUB_REF_TYPE:-}" == "tag"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'docker build "${build_args[@]}" "$BUILD_CONTEXT"'
+assert_file_contains "$CI_DOCKER_BUILD_SCRIPT_PATH" 'Build-only branch: not publishing image'
 assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")'
 assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches+=("$1")'
 assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")'
@@ -116,6 +127,34 @@ assert_contains "$supported_tooling_output" "php85"
 legacy_tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling php73 php74 || true)"
 assert_contains "$legacy_tooling_output" "php73"
 assert_contains "$legacy_tooling_output" "php74"
+
+TMP_DOCKER_BIN="$(mktemp -d "${TMPDIR:-/tmp}/ci-docker-bin.XXXXXX")"
+CI_DOCKER_LOG="$TMP_DOCKER_BIN/docker.log"
+export CI_DOCKER_LOG
+
+cat > "$TMP_DOCKER_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+printf 'docker %s\n' "$*" >> "$CI_DOCKER_LOG"
+if [[ "${1:-}" == "login" ]]; then
+    cat >/dev/null
+fi
+EOF
+chmod +x "$TMP_DOCKER_BIN/docker"
+
+build_only_ci_output="$(PATH="$TMP_DOCKER_BIN:$PATH" CI_GIT_BRANCH=latest bash "$CI_DOCKER_BUILD_SCRIPT_PATH")"
+assert_file_contains "$CI_DOCKER_LOG" 'docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from 1allen/php-apache:latest --cache-from spritsail/debian-builder:latest -f Dockerfile.ubuntu .'
+assert_contains "$build_only_ci_output" 'Build-only branch: not publishing image'
+if grep -Fq -- '-t php-apache:' "$CI_DOCKER_LOG"; then
+    echo "Expected latest build-only CI run to avoid tagging the image." >&2
+    exit 1
+fi
+
+: > "$CI_DOCKER_LOG"
+PATH="$TMP_DOCKER_BIN:$PATH" CI_GIT_BRANCH=php85 DOCKER_PASSWORD=test bash "$CI_DOCKER_BUILD_SCRIPT_PATH"
+assert_file_contains "$CI_DOCKER_LOG" 'docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from 1allen/php-apache:php85 --cache-from 1allen/php-apache:latest --cache-from spritsail/debian-builder:latest -f Dockerfile.ubuntu -t php-apache:php85 .'
+assert_file_contains "$CI_DOCKER_LOG" 'docker login -u 1allen --password-stdin'
+assert_file_contains "$CI_DOCKER_LOG" 'docker push 1allen/php-apache:php85'
+rm -rf "$TMP_DOCKER_BIN"
 
 TMP_REPO="$(mktemp -d "${TMPDIR:-/tmp}/repo-sync-test.XXXXXX")"
 trap 'rm -rf "$TMP_REPO"' EXIT

--- a/tests/repo_sync_test.sh
+++ b/tests/repo_sync_test.sh
@@ -65,7 +65,7 @@ assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGICK_VERSION=3.8.1'
 assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGICK_SHA256=3a3587c0a524c17d0dad9673a160b90cd776e836838474e173b549ed864352ee'
 assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGEMAGICK_VERSION=7.1.2-26'
 assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGEMAGICK_SHA256=d63594e334e1c410f600fb9370d78d49e4dc6f315722ca4ba083e864e5c354cb'
-assert_file_contains "$DOCKERFILE_PATH" 'mlocati/php-extension-installer:latest'
+assert_file_contains "$DOCKERFILE_PATH" 'ghcr.io/mlocati/php-extension-installer:latest'
 assert_file_contains "$DOCKERFILE_PATH" 'curl -fsSL --retry 5 --retry-connrefused --connect-timeout 15'
 assert_file_contains "$DOCKERFILE_PATH" 'sha256sum -c -'
 assert_file_contains "$DOCKERFILE_PATH" 'PKG_CONFIG_PATH=/usr/local/lib/pkgconfig'
@@ -81,11 +81,12 @@ assert_file_contains "$DOCKERFILE_PATH" 'groupmod -g "$GID" application'
 assert_file_contains "$SEMAPHORE_PATH" "when: \"branch = 'master'\""
 assert_file_contains "$SEMAPHORE_PATH" 'DOCKER_BUILDKIT'
 assert_file_contains "$SEMAPHORE_PATH" 'BUILDKIT_INLINE_CACHE=1'
-assert_file_contains "$SEMAPHORE_PATH" '--cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest"'
+assert_file_contains "$SEMAPHORE_PATH" '--cache-from $DOCKER_USERNAME/$IMAGE_NAME:latest'
 assert_file_contains "$SEMAPHORE_PATH" 'PUBLISH_IMAGE=0'
+assert_file_contains "$SEMAPHORE_PATH" 'PUBLISH_TAG=""'
 assert_file_contains "$SEMAPHORE_PATH" "grep -Eq '^php[0-9][0-9]$'"
-assert_file_contains "$SEMAPHORE_PATH" 'IMAGE_TAG="ci-${SEMAPHORE_GIT_SHA:-local}"'
-assert_file_contains "$SEMAPHORE_PATH" 'Build-only branch: not publishing'
+assert_file_contains "$SEMAPHORE_PATH" 'docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 $CACHE_FROM_ARGS -f Dockerfile.ubuntu .'
+assert_file_contains "$SEMAPHORE_PATH" 'Build-only branch: not publishing image'
 
 if grep -q "branch =~ '^php'" "$SEMAPHORE_PATH"; then
     echo "Expected Semaphore config to build phpXX branches." >&2
@@ -97,10 +98,10 @@ assert_file_contains "$SCRIPT_PATH" 'worktree prune'
 assert_file_contains "$SCRIPT_PATH" 'use_worktree_as_source_branch'
 assert_file_contains "$SCRIPT_PATH" 'curl -fsSL --retry 3 --retry-connrefused --connect-timeout 15'
 assert_file_contains "$SCRIPT_PATH" 'verify-image-tooling'
-assert_file_contains "$SCRIPT_PATH" 'sync-shared [--apply] [--legacy|--all] [branch...]'
+assert_file_contains "$SCRIPT_PATH" 'sync-shared [--apply] [branch...]'
 assert_file_contains "$SCRIPT_PATH" 'target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")'
-assert_file_contains "$TAGS_SCRIPT_PATH" 'INCLUDE_LEGACY=0'
-assert_file_contains "$TAGS_SCRIPT_PATH" '--legacy'
+assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")'
+assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches+=("$1")'
 assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")'
 assert_file_contains "$TAGS_SCRIPT_PATH" 'echo "${version:0:1}.${version:1}"'
 
@@ -108,11 +109,11 @@ tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling latest)"
 assert_contains "$tooling_output" "Image tooling branches:"
 assert_contains "$tooling_output" "latest: ok"
 
-supported_tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling)"
-assert_contains "$supported_tooling_output" "php80: ok"
-assert_contains "$supported_tooling_output" "php85: ok"
+supported_tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling || true)"
+assert_contains "$supported_tooling_output" "php80"
+assert_contains "$supported_tooling_output" "php85"
 
-legacy_tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling --legacy || true)"
+legacy_tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling php73 php74 || true)"
 assert_contains "$legacy_tooling_output" "php73"
 assert_contains "$legacy_tooling_output" "php74"
 

--- a/tests/repo_sync_test.sh
+++ b/tests/repo_sync_test.sh
@@ -23,7 +23,7 @@ assert_file_contains() {
     local file_path="$1"
     local pattern="$2"
 
-    grep -q "$pattern" "$file_path" || {
+    grep -Fq -- "$pattern" "$file_path" || {
         echo "Expected $file_path to contain: $pattern" >&2
         exit 1
     }
@@ -48,6 +48,7 @@ status_output="$(bash "$SCRIPT_PATH" status)"
 assert_contains "$status_output" "Configured PHP branches:"
 assert_contains "$status_output" "php85"
 assert_contains "$status_output" ".semaphore/semaphore.yml"
+assert_contains "$status_output" ".dockerignore"
 assert_contains "$status_output" "AGENTS.md"
 assert_contains "$status_output" "docs/maintenance.md"
 
@@ -61,11 +62,30 @@ if [[ "$dry_run_output" != *"Dry run:"* && "$dry_run_output" != *"Local branch a
 fi
 
 assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGICK_VERSION=3.8.1'
+assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGICK_SHA256=3a3587c0a524c17d0dad9673a160b90cd776e836838474e173b549ed864352ee'
 assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGEMAGICK_VERSION=7.1.2-26'
-assert_file_contains "$DOCKERFILE_PATH" 'ghcr.io/mlocati/php-extension-installer:latest'
+assert_file_contains "$DOCKERFILE_PATH" 'ARG IMAGEMAGICK_SHA256=d63594e334e1c410f600fb9370d78d49e4dc6f315722ca4ba083e864e5c354cb'
+assert_file_contains "$DOCKERFILE_PATH" 'mlocati/php-extension-installer:latest'
+assert_file_contains "$DOCKERFILE_PATH" 'curl -fsSL --retry 5 --retry-connrefused --connect-timeout 15'
+assert_file_contains "$DOCKERFILE_PATH" 'sha256sum -c -'
+assert_file_contains "$DOCKERFILE_PATH" 'PKG_CONFIG_PATH=/usr/local/lib/pkgconfig'
+assert_file_contains "$DOCKERFILE_PATH" 'make install DESTDIR=/tmp/imgck'
+assert_file_contains "$DOCKERFILE_PATH" "find /tmp/imgck/usr/local/lib -type f"
+assert_file_contains "$DOCKERFILE_PATH" 'COPY --chown=$UID:$GID --from=imagemagick-builder /tmp/imgck/usr/local/ /usr/local/'
 assert_file_contains "$DOCKERFILE_PATH" 'COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/'
 assert_file_contains "$DOCKERFILE_PATH" 'install-php-extensions gmp'
+assert_file_contains "$DOCKERFILE_PATH" 'docker-php-ext-configure imagick --with-imagick=/usr/local'
+assert_file_contains "$DOCKERFILE_PATH" 'ioncube_ini=/usr/local/etc/php/conf.d/00-ioncube.ini'
+assert_file_contains "$DOCKERFILE_PATH" 'ldd "$ioncube_loader"'
+assert_file_contains "$DOCKERFILE_PATH" 'groupmod -g "$GID" application'
 assert_file_contains "$SEMAPHORE_PATH" "when: \"branch = 'master'\""
+assert_file_contains "$SEMAPHORE_PATH" 'DOCKER_BUILDKIT'
+assert_file_contains "$SEMAPHORE_PATH" 'BUILDKIT_INLINE_CACHE=1'
+assert_file_contains "$SEMAPHORE_PATH" '--cache-from "$DOCKER_USERNAME/$IMAGE_NAME:latest"'
+assert_file_contains "$SEMAPHORE_PATH" 'PUBLISH_IMAGE=0'
+assert_file_contains "$SEMAPHORE_PATH" "grep -Eq '^php[0-9][0-9]$'"
+assert_file_contains "$SEMAPHORE_PATH" 'IMAGE_TAG="ci-${SEMAPHORE_GIT_SHA:-local}"'
+assert_file_contains "$SEMAPHORE_PATH" 'Build-only branch: not publishing'
 
 if grep -q "branch =~ '^php'" "$SEMAPHORE_PATH"; then
     echo "Expected Semaphore config to build phpXX branches." >&2
@@ -74,7 +94,15 @@ fi
 
 assert_file_contains "$SCRIPT_PATH" 'commit.gpgsign=false commit'
 assert_file_contains "$SCRIPT_PATH" 'worktree prune'
+assert_file_contains "$SCRIPT_PATH" 'use_worktree_as_source_branch'
+assert_file_contains "$SCRIPT_PATH" 'curl -fsSL --retry 3 --retry-connrefused --connect-timeout 15'
 assert_file_contains "$SCRIPT_PATH" 'verify-image-tooling'
+assert_file_contains "$SCRIPT_PATH" 'sync-shared [--apply] [--legacy|--all] [branch...]'
+assert_file_contains "$SCRIPT_PATH" 'target_branches+=("${SUPPORTED_PHP_BRANCHES[@]}")'
+assert_file_contains "$TAGS_SCRIPT_PATH" 'INCLUDE_LEGACY=0'
+assert_file_contains "$TAGS_SCRIPT_PATH" '--legacy'
+assert_file_contains "$TAGS_SCRIPT_PATH" 'target_branches=("${SUPPORTED_PHP_BRANCHES[@]}")'
+assert_file_contains "$TAGS_SCRIPT_PATH" 'echo "${version:0:1}.${version:1}"'
 
 tooling_output="$(bash "$SCRIPT_PATH" verify-image-tooling latest)"
 assert_contains "$tooling_output" "Image tooling branches:"


### PR DESCRIPTION
## Summary
- harden Docker image builds with pinned source checksums, retrying downloads, smaller context, and explicit imagick linkage against /usr/local ImageMagick
- improve Semaphore build caching and branch tooling defaults
- document multi-branch review flow and PHP 7 deprecation/freeze policy

## Validation
- bash -n scripts/repo_sync.sh scripts/tags_update.sh tests/repo_sync_test.sh
- bash tests/repo_sync_test.sh
- bash scripts/repo_sync.sh verify-image-tooling
- bash scripts/repo_sync.sh verify-image-tooling --legacy
- docker build/runtime smoke checks for latest, php73-final, and php74-final